### PR TITLE
Use coursier/coursier directly

### DIFF
--- a/coursier.rb
+++ b/coursier.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Coursier < Formula
-  head 'git://github.com/alexarchambault/coursier.git'
+  head 'git://github.com/coursier/coursier.git'
 
   def install
     bin.install 'coursier'


### PR DESCRIPTION
Saves a redirect?

Side note: Now that coursier has its own formula, would it be better to direct folks there by removing this formula?

```
brew install coursier/formulas/coursier
```

installs https://github.com/coursier/homebrew-formulas/blob/master/coursier.rb not at head.